### PR TITLE
bug: Add subnet configuration only if subnets are specified

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -162,10 +162,14 @@ resource "aws_cloudwatch_event_target" "default" {
     task_definition_arn = aws_ecs_task_definition.default.arn
     platform_version    = "1.4.0"
 
-    network_configuration {
-      assign_public_ip = false
-      security_groups  = [aws_security_group.default[0].id]
-      subnets          = var.subnet_ids
+    dynamic "network_configuration" {
+      for_each = var.subnet_ids != null ? { create : true } : {}
+
+      content {
+        assign_public_ip = false
+        security_groups  = [aws_security_group.default[0].id]
+        subnets          = var.subnet_ids
+      }
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,7 @@ variable "bucket_prefix" {
   type        = string
   default     = "/"
   description = "The prefix to use for the bucket"
+  nullable    = false
 
   validation {
     condition     = can(regex("^\\/", var.bucket_prefix))


### PR DESCRIPTION
We should not attempt any network configuration in the task definition
if no subnets were provided.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
