### PR TITLE
bug: Remove s3 data resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ module "aws-energy-labeler" {
 | [aws_ecs_cluster.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
 | [aws_iam_policy_document.ecs_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
-| [aws_s3_bucket.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   // Validate bucket and ECS cluster resources exist if specified, otherwise create them
-  bucket_name             = var.bucket_name != null ? data.aws_s3_bucket.selected[0].id : module.s3[0].id
+  bucket_name             = var.bucket_name != null ? var.bucket_name : module.s3[0].id
   bucket_name_with_prefix = format("%s%s", local.bucket_name, var.bucket_prefix)
   cluster_arn             = var.cluster_arn != null ? data.aws_ecs_cluster.selected[0].arn : aws_ecs_cluster.default[0].arn
   iam_name_prefix         = replace(title(var.name), "/[-_]/", "")
@@ -43,12 +43,6 @@ data "aws_ecs_cluster" "selected" {
   count = var.cluster_arn != null ? 1 : 0
 
   cluster_name = var.cluster_arn
-}
-
-data "aws_s3_bucket" "selected" {
-  count = var.bucket_name != null ? 1 : 0
-
-  bucket = var.bucket_name
 }
 
 data "aws_subnet" "selected" {


### PR DESCRIPTION
Was a nice to have this for buckets in the local account, but in a remote account we cannot list the bucket until this role is created and we don't want to fail the first run and then pass a role name.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
