### PR TITLE
breaking: fix count dependency error

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ module "aws-energy-labeler" {
 | [aws_ecs_task_definition.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_vpc_security_group_egress_rule.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_ecs_cluster.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
 | [aws_iam_policy_document.ecs_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
@@ -111,19 +110,21 @@ module "aws-energy-labeler" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_config"></a> [config](#input\_config) | Map containing labeler configuration options | <pre>object({<br>    allowed_account_ids        = optional(list(string), [])<br>    denied_account_ids         = optional(list(string), [])<br>    frameworks                 = optional(list(string), [])<br>    log_level                  = optional(string)<br>    report_suppressed_findings = optional(bool, false)<br>    single_account_id          = optional(string)<br>    zone_name                  = optional(string)<br>  })</pre> | n/a | yes |
+| <a name="input_config"></a> [config](#input\_config) | Map containing labeler configuration options | <pre>object({<br/>    allowed_account_ids        = optional(list(string), [])<br/>    denied_account_ids         = optional(list(string), [])<br/>    frameworks                 = optional(list(string), [])<br/>    log_level                  = optional(string)<br/>    report_suppressed_findings = optional(bool, false)<br/>    single_account_id          = optional(string)<br/>    zone_name                  = optional(string)<br/>  })</pre> | n/a | yes |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key to use for encryption | `string` | n/a | yes |
-| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the bucket to store the exported findings (will be created if not specified) | `string` | `null` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | VPC subnets in which to run the labeler tasks | `list(string)` | n/a | yes |
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the bucket to store the exported findings | `string` | `null` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | The prefix to use for the bucket | `string` | `"/"` | no |
-| <a name="input_cluster_arn"></a> [cluster\_arn](#input\_cluster\_arn) | ARN of an existing ECS cluster, if left empty a new cluster will be created | `string` | `null` | no |
+| <a name="input_cluster_arn"></a> [cluster\_arn](#input\_cluster\_arn) | ARN of an existing ECS cluster | `string` | `null` | no |
+| <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | Whether to create the S3 bucket | `bool` | `true` | no |
+| <a name="input_create_cluster"></a> [create\_cluster](#input\_create\_cluster) | Whether to create the ECS cluster | `bool` | `true` | no |
 | <a name="input_iam_permissions_boundary"></a> [iam\_permissions\_boundary](#input\_iam\_permissions\_boundary) | The permissions boundary to attach to the IAM role | `string` | `null` | no |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | The path for the IAM role | `string` | `"/"` | no |
 | <a name="input_image_uri"></a> [image\_uri](#input\_image\_uri) | The URI of the container image to use | `string` | `"ghcr.io/schubergphilis/awsenergylabeler:main"` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | The memory size of the task | `number` | `512` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name prefix of labeler resources | `string` | `"aws-energy-labeler"` | no |
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | The cron expression to be used for triggering the labeler | `string` | `"cron(0 13 ? * SUN *)"` | no |
-| <a name="input_security_group_egress_rules"></a> [security\_group\_egress\_rules](#input\_security\_group\_egress\_rules) | Security Group egress rules | <pre>list(object({<br>    cidr_ipv4                    = optional(string)<br>    cidr_ipv6                    = optional(string)<br>    description                  = string<br>    from_port                    = optional(number, 0)<br>    ip_protocol                  = optional(string, "-1")<br>    prefix_list_id               = optional(string)<br>    referenced_security_group_id = optional(string)<br>    to_port                      = optional(number, 0)<br>  }))</pre> | <pre>[<br>  {<br>    "cidr_ipv4": "0.0.0.0/0",<br>    "description": "Allow outgoing HTTPS traffic for the labeler to work",<br>    "from_port": 443,<br>    "ip_protocol": "tcp",<br>    "to_port": 443<br>  }<br>]</pre> | no |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | VPC subnet ids this lambda runs from | `list(string)` | `null` | no |
+| <a name="input_security_group_egress_rules"></a> [security\_group\_egress\_rules](#input\_security\_group\_egress\_rules) | Security Group egress rules | <pre>list(object({<br/>    cidr_ipv4                    = optional(string)<br/>    cidr_ipv6                    = optional(string)<br/>    description                  = string<br/>    from_port                    = optional(number, 0)<br/>    ip_protocol                  = optional(string, "-1")<br/>    prefix_list_id               = optional(string)<br/>    referenced_security_group_id = optional(string)<br/>    to_port                      = optional(number, 0)<br/>  }))</pre> | <pre>[<br/>  {<br/>    "cidr_ipv4": "0.0.0.0/0",<br/>    "description": "Allow outgoing HTTPS traffic for the labeler to work",<br/>    "from_port": 443,<br/>    "ip_protocol": "tcp",<br/>    "to_port": 443<br/>  }<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,11 @@
 variable "bucket_name" {
   type        = string
   default     = null
-  description = "The name of the bucket to store the exported findings (will be created if not specified)"
+  description = "The name of the bucket to store the exported findings"
 
   validation {
-    condition     = !can(regex(".*\\/$", var.bucket_name))
-    error_message = "Bucket must not end with /"
+    condition     = var.create_bucket || var.bucket_name != null
+    error_message = "bucket_name must be specified when create_bucket = false"
   }
 }
 
@@ -29,7 +29,24 @@ variable "bucket_prefix" {
 variable "cluster_arn" {
   type        = string
   default     = null
-  description = "ARN of an existing ECS cluster, if left empty a new cluster will be created"
+  description = "ARN of an existing ECS cluster"
+
+    validation {
+    condition     = var.create_cluster || var.cluster_arn != null
+    error_message = "cluster_arn must be specified when create_cluster = false"
+  }
+}
+
+variable "create_bucket" {
+  type        = bool
+  default     = true
+  description = "Whether to create the S3 bucket"
+}
+
+variable "create_cluster" {
+  type        = bool
+  default     = true
+  description = "Whether to create the ECS cluster"
 }
 
 variable "config" {
@@ -136,8 +153,7 @@ variable "security_group_egress_rules" {
 
 variable "subnet_ids" {
   type        = list(string)
-  default     = null
-  description = "VPC subnet ids this lambda runs from"
+  description = "VPC subnets in which to run the labeler tasks"
 }
 
 variable "tags" {


### PR DESCRIPTION
When an attempt is made to define ECS cluster and S3 bucket outside of the module, it creates a dependency block and results in an error.

```
│ Error: Invalid count argument
│ 
│   on .terraform/modules/aws_energy_labeler/main.tf line 45, in data "aws_ecs_cluster" "selected":
│   45:   count = var.cluster_arn != null ? 1 : 0
│ 
│ The "count" value depends on resource attributes that cannot be determined
│ until apply, so Terraform cannot predict how many instances will be
│ created. To work around this, use the -target argument to first apply only
│ the resources that the count depends on.
╵
╷
│ Error: Invalid count argument
│ 
│   on .terraform/modules/aws_energy_labeler/main.tf line 88, in resource "aws_ecs_cluster" "default":
│   88:   count = var.cluster_arn == null ? 1 : 0
│ 
│ The "count" value depends on resource attributes that cannot be determined
│ until apply, so Terraform cannot predict how many instances will be
│ created. To work around this, use the -target argument to first apply only
│ the resources that the count depends on.
╵
╷
│ Error: Invalid count argument
│ 
│   on .terraform/modules/aws_energy_labeler/main.tf line 224, in module "s3":
│  224:   count = var.bucket_name == null ? 1 : 0
│ 
│ The "count" value depends on resource attributes that cannot be determined
│ until apply, so Terraform cannot predict how many instances will be
│ created. To work around this, use the -target argument to first apply only
│ the resources that the count depends on.
╵
Operation failed: failed running terraform plan (exit 1)
```



This pull request updates the Terraform module to allow users to explicitly control whether S3 buckets and ECS clusters are created or provided externally, improving clarity and flexibility. It introduces new variables for resource creation, updates validation logic, and simplifies resource referencing throughout the code.

**Resource creation logic and variables:**

* Added `create_bucket` and `create_cluster` boolean variables to control whether the S3 bucket and ECS cluster are created by the module or provided externally, along with updated descriptions for `bucket_name` and `cluster_arn` variables.
* Updated validation for `bucket_name` and `cluster_arn` to ensure they are provided if not being created by the module. [[1]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL4-R8) [[2]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL32-R49)

**Resource referencing and conditional logic:**

* Updated logic in `main.tf` to reference created or external S3 buckets and ECS clusters based on the new `create_bucket` and `create_cluster` variables, replacing previous null checks. [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL3-R5) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL224-R210) [[3]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL83-R77)
* Removed unnecessary data sources and simplified resource references, such as eliminating the `data.aws_ecs_cluster.selected` and updating how security groups and subnets are referenced. [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL44-R54) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL83-R77) [[3]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL177-R173)

**Documentation and variable improvements:**

* Improved descriptions for variables and removed the default value from `subnet_ids` to require explicit specification.