### PR TITLE
feat: support dedicated kms key

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ module "aws-energy-labeler" {
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | The path for the IAM role | `string` | `"/"` | no |
 | <a name="input_image_uri"></a> [image\_uri](#input\_image\_uri) | The URI of the container image to use | `string` | `"ghcr.io/schubergphilis/awsenergylabeler:main"` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key to use for encryption, if not provided a new KMS key will be created | `string` | `null` | no |
+| <a name="input_kms_key_decrypt_iam_principals"></a> [kms\_key\_decrypt\_iam\_principals](#input\_kms\_key\_decrypt\_iam\_principals) | List of IAM principal ARNs allowed to decrypt the KMS key. Required if kms\_key\_arn is not set. | `list(string)` | `null` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | The memory size of the task | `number` | `512` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name prefix of labeler resources | `string` | `"aws-energy-labeler"` | no |
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | The cron expression to be used for triggering the labeler | `string` | `"cron(0 13 ? * SUN *)"` | no |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ module "aws-energy-labeler" {
 |------|--------|---------|
 | <a name="module_aws_ecs_container_definition"></a> [aws\_ecs\_container\_definition](#module\_aws\_ecs\_container\_definition) | terraform-aws-modules/ecs/aws//modules/container-definition | ~> 5.11.4 |
 | <a name="module_iam_role"></a> [iam\_role](#module\_iam\_role) | schubergphilis/mcaf-role/aws | ~> 0.4.0 |
+| <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | schubergphilis/mcaf-kms/aws | ~> 0.3.0 |
 | <a name="module_s3"></a> [s3](#module\_s3) | schubergphilis/mcaf-s3/aws | ~> 0.14.1 |
 
 ## Resources
@@ -106,10 +107,14 @@ module "aws-energy-labeler" {
 | [aws_cloudwatch_event_target.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_ecs_cluster.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
 | [aws_ecs_task_definition.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_kms_key_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_vpc_security_group_egress_rule.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ecs_cluster.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
 | [aws_iam_policy_document.ecs_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_session_context.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_session_context) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
@@ -117,19 +122,19 @@ module "aws-energy-labeler" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_config"></a> [config](#input\_config) | Map containing labeler configuration options | <pre>object({<br>    allowed_account_ids        = optional(list(string), [])<br>    denied_account_ids         = optional(list(string), [])<br>    frameworks                 = optional(list(string), [])<br>    log_level                  = optional(string)<br>    report_suppressed_findings = optional(bool, false)<br>    single_account_id          = optional(string)<br>    zone_name                  = optional(string)<br>  })</pre> | n/a | yes |
-| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key to use for encryption | `string` | n/a | yes |
+| <a name="input_config"></a> [config](#input\_config) | Map containing labeler configuration options | <pre>object({<br/>    allowed_account_ids        = optional(list(string), [])<br/>    denied_account_ids         = optional(list(string), [])<br/>    frameworks                 = optional(list(string), [])<br/>    log_level                  = optional(string)<br/>    report_suppressed_findings = optional(bool, false)<br/>    single_account_id          = optional(string)<br/>    zone_name                  = optional(string)<br/>  })</pre> | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | VPC subnet ids where the labeler will be deployed | `list(string)` | n/a | yes |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the bucket to store the exported findings (will be created if not specified) | `string` | `null` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | The prefix to use for the bucket | `string` | `"/"` | no |
 | <a name="input_cluster_arn"></a> [cluster\_arn](#input\_cluster\_arn) | ARN of an existing ECS cluster, if left empty a new cluster will be created | `string` | `null` | no |
 | <a name="input_iam_permissions_boundary"></a> [iam\_permissions\_boundary](#input\_iam\_permissions\_boundary) | The permissions boundary to attach to the IAM role | `string` | `null` | no |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | The path for the IAM role | `string` | `"/"` | no |
 | <a name="input_image_uri"></a> [image\_uri](#input\_image\_uri) | The URI of the container image to use | `string` | `"ghcr.io/schubergphilis/awsenergylabeler:main"` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key to use for encryption, if not provided a new KMS key will be created | `string` | `null` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | The memory size of the task | `number` | `512` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name prefix of labeler resources | `string` | `"aws-energy-labeler"` | no |
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | The cron expression to be used for triggering the labeler | `string` | `"cron(0 13 ? * SUN *)"` | no |
-| <a name="input_security_group_egress_rules"></a> [security\_group\_egress\_rules](#input\_security\_group\_egress\_rules) | Security Group egress rules | <pre>list(object({<br>    cidr_ipv4                    = optional(string)<br>    cidr_ipv6                    = optional(string)<br>    description                  = string<br>    from_port                    = optional(number, 0)<br>    ip_protocol                  = optional(string, "-1")<br>    prefix_list_id               = optional(string)<br>    referenced_security_group_id = optional(string)<br>    to_port                      = optional(number, 0)<br>  }))</pre> | <pre>[<br>  {<br>    "cidr_ipv4": "0.0.0.0/0",<br>    "description": "Allow outgoing HTTPS traffic for the labeler to work",<br>    "from_port": 443,<br>    "ip_protocol": "tcp",<br>    "to_port": 443<br>  }<br>]</pre> | no |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | VPC subnet ids this lambda runs from | `list(string)` | `null` | no |
+| <a name="input_security_group_egress_rules"></a> [security\_group\_egress\_rules](#input\_security\_group\_egress\_rules) | Security Group egress rules | <pre>list(object({<br/>    cidr_ipv4                    = optional(string)<br/>    cidr_ipv6                    = optional(string)<br/>    description                  = string<br/>    from_port                    = optional(number, 0)<br/>    ip_protocol                  = optional(string, "-1")<br/>    prefix_list_id               = optional(string)<br/>    referenced_security_group_id = optional(string)<br/>    to_port                      = optional(number, 0)<br/>  }))</pre> | <pre>[<br/>  {<br/>    "cidr_ipv4": "0.0.0.0/0",<br/>    "description": "Allow outgoing HTTPS traffic for the labeler to work",<br/>    "from_port": 443,<br/>    "ip_protocol": "tcp",<br/>    "to_port": 443<br/>  }<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # terraform-aws-mcaf-energy-labeler
 
+```markdown
+## ⚠️ Caution: Resource Creation in the same Run
+
+If you create the KMS Key, ECS Cluster, or S3 bucket in the same Terraform run or workspace as this module, you may encounter errors such as `cannot compute count value`. To avoid this, create these resources in a separate run or ensure they exist before applying this module.
+```
+
 Terraform module to create an ECS scheduled task that periodically generates an AWS energy label based on [awsenergylabelerlib](https://github.com/schubergphilis/awsenergylabelerlib).
 
 This module should be run in the AWS account that collects your aggregated Security Hub findings. In a typical Control Tower deployment, this would be the Audit account.

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,17 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_ecs_cluster" "selected" {
+  count = var.cluster_arn != null ? 1 : 0
+
+  cluster_name = var.cluster_arn
+}
+
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
+data "aws_region" "current" {}
+
+data "aws_subnet" "selected" {
+  id = var.subnet_ids[0]
+}

--- a/kms.tf
+++ b/kms.tf
@@ -112,6 +112,21 @@ data "aws_iam_policy_document" "kms_key_policy" {
       identifiers = [module.iam_role["task"].arn]
     }
   }
+
+  statement {
+    sid       = "Permissions to Decrypt for specified IAM principals"
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"]
+
+    actions = [
+      "kms:Decrypt"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.kms_key_decrypt_iam_principals
+    }
+  }
 }
 
 module "kms_key" {

--- a/kms.tf
+++ b/kms.tf
@@ -1,0 +1,122 @@
+data "aws_iam_policy_document" "kms_key_policy" {
+  statement {
+    sid       = "Base Permissions for root user"
+    actions   = ["kms:*"]
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalType"
+      values   = ["Account"]
+    }
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      ]
+    }
+  }
+
+  statement {
+    sid = "Read/List permissions for all IAM users"
+    actions = [
+      "kms:Describe*",
+      "kms:GetKeyPolicy",
+      "kms:ListAliases",
+      "kms:ListKeys"
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      ]
+    }
+  }
+
+  statement {
+    sid = "Administrative permissions"
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Decrypt",
+      "kms:DeleteAlias",
+      "kms:Enable*",
+      "kms:Encrypt",
+      "kms:Get*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:ReplicateKey",
+      "kms:Revoke*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:Update*"
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_iam_session_context.current.issuer_arn]
+    }
+  }
+
+  statement {
+    sid = "Permissions for Cloudwatch log groups in this account"
+    actions = [
+      "kms:Decrypt",
+      "kms:Describe*",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*"
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "kms:EncryptionContext:aws:logs:arn"
+
+      values = [
+        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      ]
+    }
+  }
+
+  statement {
+    sid = "Permissions for energy labeler ECS task role"
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*"
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.iam_name_prefix}EcsTaskRole"]
+    }
+  }
+}
+
+module "kms_key" {
+  count = var.kms_key_arn == null ? 1 : 0
+
+  source  = "schubergphilis/mcaf-kms/aws"
+  version = "~> 0.3.0"
+
+  name        = var.name
+  description = "KMS key used for encrypting all energy labeler resources"
+  policy      = data.aws_iam_policy_document.kms_key_policy.json
+}

--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,9 @@ data "aws_iam_policy_document" "ecs_task" {
   # checkov:skip=CKV_AWS_356: Cannot set limit resources for security hub or org
 
   statement {
-    sid = "AllowReadOrg"
+    sid       = "AllowReadOrg"
+    resources = ["*"]
+
     actions = [
       "ec2:DescribeRegions",
       "iam:ListAccountAliases",
@@ -86,17 +88,17 @@ data "aws_iam_policy_document" "ecs_task" {
       "organizations:DescribeOrganization",
       "organizations:ListAccounts",
     ]
-    resources = ["*"]
   }
 
   statement {
-    sid = "AllowReadSecurityHub"
+    sid       = "AllowReadSecurityHub"
+    resources = ["*"]
+
     actions = [
       "securityhub:GetFindings",
       "securityhub:ListEnabledProductsForImport",
       "securityhub:ListFindingAggregators",
     ]
-    resources = ["*"]
   }
 
   statement {
@@ -106,14 +108,15 @@ data "aws_iam_policy_document" "ecs_task" {
   }
 
   statement {
-    sid = "AllowUseKMS"
+    sid       = "AllowUseKMS"
+    resources = [local.kms_key_arn]
+
     actions = [
       "kms:Decrypt",
       "kms:Encrypt",
       "kms:GenerateDataKey*",
       "kms:ReEncrypt*",
     ]
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"]
   }
 }
 
@@ -179,6 +182,8 @@ module "aws_ecs_container_definition" {
     }
     if value != null
   ]
+
+  depends_on = [aws_kms_key_policy.default]
 }
 
 resource "aws_ecs_task_definition" "default" {

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ locals {
   bucket_name_with_prefix = format("%s%s", local.bucket_name, var.bucket_prefix)
   cluster_arn             = var.cluster_arn != null ? data.aws_ecs_cluster.selected[0].arn : aws_ecs_cluster.default[0].arn
   iam_name_prefix         = replace(title(var.name), "/[-_]/", "")
+  kms_key_arn             = var.kms_key_arn != null ? var.kms_key_arn : module.kms_key[0].arn
 
   // Sanitize the ECS task environment variables
   config = merge(
@@ -41,18 +42,6 @@ locals {
   }
 }
 
-data "aws_ecs_cluster" "selected" {
-  count = var.cluster_arn != null ? 1 : 0
-
-  cluster_name = var.cluster_arn
-}
-
-data "aws_subnet" "selected" {
-  id = var.subnet_ids[0]
-}
-
-data "aws_region" "current" {}
-
 resource "aws_security_group" "default" {
   # checkov:skip=CKV2_AWS_5: False positive finding, the security group is attached.
   name        = var.name
@@ -75,7 +64,7 @@ resource "aws_vpc_security_group_egress_rule" "default" {
   ip_protocol                  = each.value.ip_protocol
   prefix_list_id               = each.value.prefix_list_id
   referenced_security_group_id = each.value.referenced_security_group_id
-  security_group_id            = aws_security_group.default[0].id
+  security_group_id            = aws_security_group.default.id
   to_port                      = each.value.to_port
 }
 
@@ -89,9 +78,7 @@ data "aws_iam_policy_document" "ecs_task" {
   # checkov:skip=CKV_AWS_356: Cannot set limit resources for security hub or org
 
   statement {
-    sid       = "AllowReadOrg"
-    resources = ["*"]
-
+    sid = "AllowReadOrg"
     actions = [
       "ec2:DescribeRegions",
       "iam:ListAccountAliases",
@@ -99,17 +86,17 @@ data "aws_iam_policy_document" "ecs_task" {
       "organizations:DescribeOrganization",
       "organizations:ListAccounts",
     ]
+    resources = ["*"]
   }
 
   statement {
-    sid       = "AllowReadSecurityHub"
-    resources = ["*"]
-
+    sid = "AllowReadSecurityHub"
     actions = [
       "securityhub:GetFindings",
       "securityhub:ListEnabledProductsForImport",
       "securityhub:ListFindingAggregators",
     ]
+    resources = ["*"]
   }
 
   statement {
@@ -118,20 +105,15 @@ data "aws_iam_policy_document" "ecs_task" {
     resources = ["arn:aws:s3:::${local.bucket_name_with_prefix}*"]
   }
 
-  dynamic "statement" {
-    for_each = var.kms_key_arn != null ? { create = true } : {}
-
-    content {
-      sid       = "AllowUseKMS"
-      resources = [var.kms_key_arn]
-
-      actions = [
-        "kms:Decrypt",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
-      ]
-    }
+  statement {
+    sid = "AllowUseKMS"
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*",
+    ]
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"]
   }
 }
 
@@ -170,12 +152,12 @@ resource "aws_cloudwatch_event_target" "default" {
     platform_version    = "1.4.0"
 
     network_configuration {
-        assign_public_ip = false
-        security_groups  = [aws_security_group.default.id]
-        subnets          = var.subnet_ids
-      }
+      assign_public_ip = false
+      security_groups  = [aws_security_group.default.id]
+      subnets          = var.subnet_ids
     }
   }
+}
 
 module "aws_ecs_container_definition" {
   source  = "terraform-aws-modules/ecs/aws//modules/container-definition"
@@ -184,7 +166,7 @@ module "aws_ecs_container_definition" {
   name                            = var.name
   cloudwatch_log_group_name       = "/aws/ecs/${var.name}"
   create_cloudwatch_log_group     = true
-  cloudwatch_log_group_kms_key_id = var.kms_key_arn
+  cloudwatch_log_group_kms_key_id = local.kms_key_arn
   essential                       = true
   image                           = var.image_uri
   readonly_root_filesystem        = true
@@ -218,7 +200,7 @@ module "s3" {
   version = "~> 0.14.1"
 
   name_prefix = "${lower(var.name)}-"
-  kms_key_arn = var.kms_key_arn
+  kms_key_arn = local.kms_key_arn
   versioning  = true
   tags        = var.tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -50,12 +50,6 @@ variable "config" {
   }
 }
 
-variable "kms_key_arn" {
-  type        = string
-  default     = null
-  description = "The ARN of the KMS key to use for encryption, if not provided a new KMS key will be created"
-}
-
 variable "iam_role_path" {
   type        = string
   default     = "/"
@@ -72,6 +66,25 @@ variable "image_uri" {
   type        = string
   default     = "ghcr.io/schubergphilis/awsenergylabeler:main"
   description = "The URI of the container image to use"
+}
+
+variable "kms_key_arn" {
+  type        = string
+  default     = null
+  description = "The ARN of the KMS key to use for encryption, if not provided a new KMS key will be created"
+}
+
+variable "kms_key_decrypt_iam_principals" {
+  type        = list(string)
+  default     = null
+  description = "List of IAM principal ARNs allowed to decrypt the KMS key. Required if kms_key_arn is not set."
+
+  validation {
+    condition = (
+      var.kms_key_arn == null ? var.kms_key_decrypt_iam_principals != null && length(var.kms_key_decrypt_iam_principals) > 0 : true
+    )
+    error_message = "If kms_key_arn is not set, kms_key_decrypt_iam_principals must be defined and not empty."
+  }
 }
 
 variable "memory" {

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,8 @@ variable "config" {
 
 variable "kms_key_arn" {
   type        = string
-  description = "The ARN of the KMS key to use for encryption"
+  default     = null
+  description = "The ARN of the KMS key to use for encryption, if not provided a new KMS key will be created"
 }
 
 variable "iam_role_path" {
@@ -136,8 +137,7 @@ variable "security_group_egress_rules" {
 
 variable "subnet_ids" {
   type        = list(string)
-  default     = null
-  description = "VPC subnet ids this lambda runs from"
+  description = "VPC subnet ids where the labeler will be deployed"
 }
 
 variable "tags" {


### PR DESCRIPTION
This pull request introduces support for automatic creation and management of a KMS key for resource encryption within the module, removing the requirement for users to always supply a KMS key ARN. It also refactors how AWS data sources and resource references are handled, improving reliability when resources are created in the same Terraform run. Documentation has been updated to warn users about potential issues when creating certain resources together.
