### PR TITLE
chore: output ecs cluster and s3 bucket attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ module "aws-energy-labeler" {
 
 | Name | Description |
 |------|-------------|
+| <a name="output_ecs_cluster_arn"></a> [ecs\_cluster\_arn](#output\_ecs\_cluster\_arn) | value of the ecs cluster arn |
+| <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | value of the s3 bucket arn |
+| <a name="output_s3_bucket_name"></a> [s3\_bucket\_name](#output\_s3\_bucket\_name) | value of the s3 bucket name |
 | <a name="output_task_role_arn"></a> [task\_role\_arn](#output\_task\_role\_arn) | value of the task role arn |
 <!-- END_TF_DOCS -->
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
   // Validate bucket and ECS cluster resources exist if specified, otherwise create them
+  bucket_arn              = var.bucket_name != null ? "arn:aws:s3:::${var.bucket_name}" : module.s3[0].arn
   bucket_name             = var.bucket_name != null ? var.bucket_name : module.s3[0].id
   bucket_name_with_prefix = format("%s%s", local.bucket_name, var.bucket_prefix)
   cluster_arn             = var.cluster_arn != null ? data.aws_ecs_cluster.selected[0].arn : aws_ecs_cluster.default[0].arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,18 @@
+output "ecs_cluster_arn" {
+  value       = local.cluster_arn
+  description = "value of the ecs cluster arn"
+}
+
+output "s3_bucket_arn" {
+  value       = local.bucket_arn
+  description = "value of the s3 bucket arn"
+}
+
+output "s3_bucket_name" {
+  value       = local.bucket_name
+  description = "value of the s3 bucket name"
+}
+
 output "task_role_arn" {
   value       = module.iam_role["task"].arn
   description = "value of the task role arn"


### PR DESCRIPTION
This pull request adds new Terraform outputs to improve visibility into important resource identifiers. The changes primarily provide direct access to the ARNs and names of the ECS cluster and S3 bucket, making it easier to reference these resources in other modules or outputs.

New resource outputs:

* Added `ecs_cluster_arn` output to expose the ARN of the ECS cluster.
* Added `s3_bucket_arn` output to expose the ARN of the S3 bucket.
* Added `s3_bucket_name` output to expose the name of the S3 bucket.