### PR TITLE
chore: bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ module "aws-energy-labeler" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_ecs_container_definition"></a> [aws\_ecs\_container\_definition](#module\_aws\_ecs\_container\_definition) | terraform-aws-modules/ecs/aws//modules/container-definition | ~> 5.11.4 |
-| <a name="module_iam_role"></a> [iam\_role](#module\_iam\_role) | schubergphilis/mcaf-role/aws | ~> 0.4.0 |
-| <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | schubergphilis/mcaf-kms/aws | ~> 0.3.0 |
-| <a name="module_s3"></a> [s3](#module\_s3) | schubergphilis/mcaf-s3/aws | ~> 0.14.1 |
+| <a name="module_aws_ecs_container_definition"></a> [aws\_ecs\_container\_definition](#module\_aws\_ecs\_container\_definition) | terraform-aws-modules/ecs/aws//modules/container-definition | ~> 5.12.1 |
+| <a name="module_iam_role"></a> [iam\_role](#module\_iam\_role) | schubergphilis/mcaf-role/aws | ~> 0.5.3 |
+| <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | schubergphilis/mcaf-kms/aws | ~> 0.3.1 |
+| <a name="module_s3"></a> [s3](#module\_s3) | schubergphilis/mcaf-s3/aws | ~> 1.5.2 |
 
 ## Resources
 
@@ -131,7 +131,7 @@ module "aws-energy-labeler" {
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | The path for the IAM role | `string` | `"/"` | no |
 | <a name="input_image_uri"></a> [image\_uri](#input\_image\_uri) | The URI of the container image to use | `string` | `"ghcr.io/schubergphilis/awsenergylabeler:main"` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key to use for encryption, if not provided a new KMS key will be created | `string` | `null` | no |
-| <a name="input_kms_key_decrypt_iam_principals"></a> [kms\_key\_decrypt\_iam\_principals](#input\_kms\_key\_decrypt\_iam\_principals) | List of IAM principal ARNs allowed to decrypt the KMS key. Required if kms\_key\_arn is not set. | `list(string)` | `null` | no |
+| <a name="input_kms_key_decrypt_iam_principals"></a> [kms\_key\_decrypt\_iam\_principals](#input\_kms\_key\_decrypt\_iam\_principals) | List of IAM principal ARNs allowed to decrypt the KMS key. Required if kms\_key\_arn is not set. | `list(string)` | `[]` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | The memory size of the task | `number` | `512` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name prefix of labeler resources | `string` | `"aws-energy-labeler"` | no |
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | The cron expression to be used for triggering the labeler | `string` | `"cron(0 13 ? * SUN *)"` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.39.0"
+      version = ">= 5.20"
     }
   }
 }
@@ -19,6 +19,10 @@ module "aws-energy-labeler-single-account" {
   config = {
     single_account_id = "123456789012"
   }
+
+  subnet_ids = [
+    "subnet-12345678"
+  ]
 }
 
 module "aws-energy-labeler-zone" {
@@ -29,4 +33,8 @@ module "aws-energy-labeler-zone" {
   config = {
     zone_name = "MYZONE"
   }
+
+  subnet_ids = [
+    "subnet-12345678"
+  ]
 }

--- a/kms.tf
+++ b/kms.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
   statement {
     sid       = "Read/List permissions for all IAM users"
     effect    = "Allow"
-    resources = ["*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"]
 
     actions = [
       "kms:Describe*",

--- a/kms.tf
+++ b/kms.tf
@@ -133,7 +133,7 @@ module "kms_key" {
   count = var.kms_key_arn == null ? 1 : 0
 
   source  = "schubergphilis/mcaf-kms/aws"
-  version = "~> 0.3.0"
+  version = "~> 0.3.1"
 
   name        = var.name
   description = "KMS key used for encrypting all energy labeler resources"

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ module "iam_role" {
   for_each = local.roles
 
   source  = "schubergphilis/mcaf-role/aws"
-  version = "~> 0.4.0"
+  version = "~> 0.5.3"
 
   name                  = each.value.name
   create_policy         = try(each.value.create_policy, null)
@@ -164,7 +164,7 @@ resource "aws_cloudwatch_event_target" "default" {
 
 module "aws_ecs_container_definition" {
   source  = "terraform-aws-modules/ecs/aws//modules/container-definition"
-  version = "~> 5.11.4"
+  version = "~> 5.12.1"
 
   name                            = var.name
   cloudwatch_log_group_name       = "/aws/ecs/${var.name}"
@@ -202,7 +202,7 @@ module "s3" {
   count = var.bucket_name == null ? 1 : 0
 
   source  = "schubergphilis/mcaf-s3/aws"
-  version = "~> 0.14.1"
+  version = "~> 1.5.2"
 
   name_prefix = "${lower(var.name)}-"
   kms_key_arn = local.kms_key_arn
@@ -222,10 +222,12 @@ module "s3" {
         days = 90
       }
 
-      transition = {
-        days          = 30
-        storage_class = "STANDARD_IA"
-      }
+      transition = [
+        {
+          days          = 30
+          storage_class = "STANDARD_IA"
+        }
+      ]
     }
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -76,7 +76,7 @@ variable "kms_key_arn" {
 
 variable "kms_key_decrypt_iam_principals" {
   type        = list(string)
-  default     = null
+  default     = []
   description = "List of IAM principal ARNs allowed to decrypt the KMS key. Required if kms_key_arn is not set."
 
   validation {


### PR DESCRIPTION
## :hammer_and_wrench: Summary

- bump the versions of the following modules:
  - [patch] schubergphilis/mcaf-kms/aws
  - [minor] schubergphilis/mcaf-role/aws
  - [minor] terraform-aws-modules/ecs/aws//modules/container-definition
  - [major] schubergphilis/mcaf-s3/aws

- fix the bug that throws the error `The argument "statement.5.principals.0.identifiers" is required, but no definition was found.` when `var.kms_key_arn` is defined while `var.kms_key_decrypt_iam_principals` is empty

## :rocket: Motivation

This PR is for fixing any bugs and bumping the latest non-breaking updates in preparation for the aws provider v6 migration

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
