### PR TITLE
breaking: support AWS provider v6 and resolve deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ module "aws-energy-labeler" {
 |------|--------|---------|
 | <a name="module_aws_ecs_container_definition"></a> [aws\_ecs\_container\_definition](#module\_aws\_ecs\_container\_definition) | terraform-aws-modules/ecs/aws//modules/container-definition | ~> 7.5.0 |
 | <a name="module_iam_role"></a> [iam\_role](#module\_iam\_role) | schubergphilis/mcaf-role/aws | ~> 0.5.3 |
-| <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | schubergphilis/mcaf-kms/aws | ~> 0.3.1 |
+| <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | schubergphilis/mcaf-kms/aws | ~> 2.2.0 |
 | <a name="module_s3"></a> [s3](#module\_s3) | schubergphilis/mcaf-s3/aws | ~> 3.0.0 |
 
 ## Resources
@@ -115,6 +115,7 @@ module "aws-energy-labeler" {
 | [aws_iam_policy_document.ecs_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_session_context.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_session_context) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
@@ -130,6 +131,7 @@ module "aws-energy-labeler" {
 | <a name="input_iam_permissions_boundary"></a> [iam\_permissions\_boundary](#input\_iam\_permissions\_boundary) | The permissions boundary to attach to the IAM role | `string` | `null` | no |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | The path for the IAM role | `string` | `"/"` | no |
 | <a name="input_image_uri"></a> [image\_uri](#input\_image\_uri) | The URI of the container image to use | `string` | `"ghcr.io/schubergphilis/awsenergylabeler:main"` | no |
+| <a name="input_kms_key_administrator_iam_principals"></a> [kms\_key\_administrator\_iam\_principals](#input\_kms\_key\_administrator\_iam\_principals) | List of IAM principal ARNs allowed to administer the KMS key. | `list(string)` | `[]` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key to use for encryption, if not provided a new KMS key will be created | `string` | `null` | no |
 | <a name="input_kms_key_decrypt_iam_principals"></a> [kms\_key\_decrypt\_iam\_principals](#input\_kms\_key\_decrypt\_iam\_principals) | List of IAM principal ARNs allowed to decrypt the KMS key. Required if kms\_key\_arn is not set. | `list(string)` | `[]` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | The memory size of the task | `number` | `512` | no |

--- a/README.md
+++ b/README.md
@@ -82,22 +82,22 @@ module "aws-energy-labeler" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_ecs_container_definition"></a> [aws\_ecs\_container\_definition](#module\_aws\_ecs\_container\_definition) | terraform-aws-modules/ecs/aws//modules/container-definition | ~> 5.12.1 |
+| <a name="module_aws_ecs_container_definition"></a> [aws\_ecs\_container\_definition](#module\_aws\_ecs\_container\_definition) | terraform-aws-modules/ecs/aws//modules/container-definition | ~> 7.5.0 |
 | <a name="module_iam_role"></a> [iam\_role](#module\_iam\_role) | schubergphilis/mcaf-role/aws | ~> 0.5.3 |
 | <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | schubergphilis/mcaf-kms/aws | ~> 0.3.1 |
-| <a name="module_s3"></a> [s3](#module\_s3) | schubergphilis/mcaf-s3/aws | ~> 1.5.2 |
+| <a name="module_s3"></a> [s3](#module\_s3) | schubergphilis/mcaf-s3/aws | ~> 3.0.0 |
 
 ## Resources
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,16 @@
+# Upgrading Notes
+
+This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
+
+## Upgrading to v1.0.0
+
+### Key Changes
+
+- This module now requires a minimum AWS provider version of `6.0`. The `name` attribute of the `aws_region` data source was deprecated in AWS provider `6.0` in favor of `region`, and the child modules bundled with this module now require provider `6.x`. If you are using multiple AWS provider blocks, please read [migrating from multiple provider configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support#migrating-from-multiple-provider-configurations).
+- The bundled `schubergphilis/mcaf-s3/aws` module has been upgraded from `~> 1.5.2` to `~> 3.0.0`. As of `3.0.0`, server-side encryption with customer-provided keys (`SSE-C`) is blocked by default. This module encrypts the bucket with a KMS key (`SSE-KMS`), so this change has no functional impact on the energy labeler.
+- The bundled `terraform-aws-modules/ecs/aws//modules/container-definition` module has been upgraded from `~> 5.12.1` to `~> 7.5.0`.
+
+### Required Actions
+
+- Ensure the AWS provider used in the calling configuration is `>= 6.0`.
+- No changes to this module's input variables or outputs are required.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,6 +9,7 @@ This document captures required refactoring on your part when upgrading to a mod
 - This module now requires a minimum AWS provider version of `6.0`. The `name` attribute of the `aws_region` data source was deprecated in AWS provider `6.0` in favor of `region`, and the child modules bundled with this module now require provider `6.x`. If you are using multiple AWS provider blocks, please read [migrating from multiple provider configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support#migrating-from-multiple-provider-configurations).
 - The bundled `schubergphilis/mcaf-s3/aws` module has been upgraded from `~> 1.5.2` to `~> 3.0.0`. As of `3.0.0`, server-side encryption with customer-provided keys (`SSE-C`) is blocked by default. This module encrypts the bucket with a KMS key (`SSE-KMS`), so this change has no functional impact on the energy labeler.
 - The bundled `terraform-aws-modules/ecs/aws//modules/container-definition` module has been upgraded from `~> 5.12.1` to `~> 7.5.0`.
+- Sync internal KMS key policy with latest version from the [mcaf-kms](https://github.com/schubergphilis/terraform-aws-mcaf-kms/blob/master/UPGRADING.md#upgrading-to-v200) module, the internal key policy of the module cannot be used due to a cyclic dependency issue.
 
 ### Required Actions
 

--- a/data.tf
+++ b/data.tf
@@ -10,6 +10,8 @@ data "aws_iam_session_context" "current" {
   arn = data.aws_caller_identity.current.arn
 }
 
+data "aws_partition" "current" {}
+
 data "aws_region" "current" {}
 
 data "aws_subnet" "selected" {

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,40 +1,17 @@
-terraform {
-  required_version = ">= 1.9"
-
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 6.0"
-    }
-  }
-}
-
 provider "aws" {}
 
 module "aws-energy-labeler-single-account" {
   source = "../../"
 
-  kms_key_arn = "arn:aws:kms:eu-west-1:123456789012:key/1234abcd-12ab-34cd-56ef-123456789012"
-
-  config = {
-    single_account_id = "123456789012"
-  }
-
-  subnet_ids = [
-    "subnet-12345678"
-  ]
+  config                         = { single_account_id = "123456789012" }
+  kms_key_decrypt_iam_principals = ["arn:aws:iam::123456789012:role/MyRole"]
+  subnet_ids                     = ["subnet-12345678"]
 }
 
 module "aws-energy-labeler-zone" {
   source = "../../"
 
-  kms_key_arn = "arn:aws:kms:eu-west-1:123456789012:key/1234abcd-12ab-34cd-56ef-123456789012"
-
-  config = {
-    zone_name = "MYZONE"
-  }
-
-  subnet_ids = [
-    "subnet-12345678"
-  ]
+  config                         = { zone_name = "MYZONE" }
+  kms_key_decrypt_iam_principals = ["arn:aws:iam::123456789012:role/MyRole"]
+  subnet_ids                     = ["subnet-12345678"]
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.20"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/kms.tf
+++ b/kms.tf
@@ -3,7 +3,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
     sid       = "Base Permissions for root user"
     actions   = ["kms:*"]
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"]
 
     condition {
       test     = "StringEquals"
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
   statement {
     sid       = "Read/List permissions for all IAM users"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"]
 
     actions = [
       "kms:Describe*",
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
   statement {
     sid       = "Administrative permissions"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"]
 
     actions = [
       "kms:Create*",
@@ -70,7 +70,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
   statement {
     sid       = "Permissions for Cloudwatch log group"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"]
 
     actions = [
       "kms:Decrypt",
@@ -82,7 +82,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
 
     principals {
       type        = "Service"
-      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+      identifiers = ["logs.${data.aws_region.current.region}.amazonaws.com"]
     }
 
     condition {
@@ -90,7 +90,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
       variable = "kms:EncryptionContext:aws:logs:arn"
 
       values = [
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/ecs/${var.name}"
+        "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/ecs/${var.name}"
       ]
     }
   }
@@ -98,7 +98,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
   statement {
     sid       = "Permissions for energy labeler ECS task role"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"]
 
     actions = [
       "kms:Decrypt",
@@ -116,7 +116,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
   statement {
     sid       = "Permissions to Decrypt for specified IAM principals"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"]
 
     actions = [
       "kms:Decrypt"

--- a/kms.tf
+++ b/kms.tf
@@ -1,9 +1,23 @@
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  partition  = data.aws_partition.current.partition
+  region     = data.aws_region.current.region
+
+  # If no administrators are specified, fall back to the current caller so the key
+  # never ends up without a principal able to manage it.
+  iam_administrator = coalescelist(var.kms_key_administrator_iam_principals, [data.aws_iam_session_context.current.issuer_arn])
+}
+
 data "aws_iam_policy_document" "kms_key_policy" {
+  # checkov:skip=CKV_AWS_111: Ensure IAM policies does not allow write access without constraints - False positive, this is a KMS key policy
+  # checkov:skip=CKV_AWS_356: Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions - False positive, this is a KMS key policy
+  # checkov:skip=CKV_AWS_109: Ensure IAM policies does not allow permissions management / resource exposure without constraints - False positive, this is a KMS key policy
+
   statement {
     sid       = "Base Permissions for root user"
     actions   = ["kms:*"]
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"]
+    resources = ["*"]
 
     condition {
       test     = "StringEquals"
@@ -12,17 +26,15 @@ data "aws_iam_policy_document" "kms_key_policy" {
     }
 
     principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
-      ]
+      type        = "AWS"
+      identifiers = ["arn:${local.partition}:iam::${local.account_id}:root"]
     }
   }
 
   statement {
     sid       = "Read/List permissions for all IAM users"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"]
+    resources = ["*"]
 
     actions = [
       "kms:Describe*",
@@ -31,31 +43,33 @@ data "aws_iam_policy_document" "kms_key_policy" {
       "kms:ListKeys"
     ]
 
+
     principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
-      ]
+      type        = "AWS"
+      identifiers = ["arn:${local.partition}:iam::${local.account_id}:root"]
     }
   }
 
   statement {
     sid       = "Administrative permissions"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"]
+    resources = ["*"]
 
     actions = [
+      "kms:CancelKeyDeletion",
       "kms:Create*",
+      "kms:Delete*",
       "kms:Describe*",
-      "kms:Decrypt",
-      "kms:DeleteAlias",
+      "kms:Disable*",
       "kms:Enable*",
-      "kms:Encrypt",
       "kms:Get*",
+      "kms:ImportKeyMaterial",
       "kms:List*",
       "kms:Put*",
       "kms:ReplicateKey",
       "kms:Revoke*",
+      "kms:RotateKeyOnDemand",
+      "kms:ScheduleKeyDeletion",
       "kms:TagResource",
       "kms:UntagResource",
       "kms:Update*"
@@ -63,14 +77,14 @@ data "aws_iam_policy_document" "kms_key_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = [data.aws_iam_session_context.current.issuer_arn]
+      identifiers = local.iam_administrator
     }
   }
 
   statement {
     sid       = "Permissions for Cloudwatch log group"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"]
+    resources = ["*"]
 
     actions = [
       "kms:Decrypt",
@@ -82,7 +96,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
 
     principals {
       type        = "Service"
-      identifiers = ["logs.${data.aws_region.current.region}.amazonaws.com"]
+      identifiers = ["logs.${local.region}.amazonaws.com"]
     }
 
     condition {
@@ -90,7 +104,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
       variable = "kms:EncryptionContext:aws:logs:arn"
 
       values = [
-        "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/ecs/${var.name}"
+        "arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/ecs/${var.name}"
       ]
     }
   }
@@ -98,7 +112,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
   statement {
     sid       = "Permissions for energy labeler ECS task role"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"]
+    resources = ["*"]
 
     actions = [
       "kms:Decrypt",
@@ -116,7 +130,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
   statement {
     sid       = "Permissions to Decrypt for specified IAM principals"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"]
+    resources = ["*"]
 
     actions = [
       "kms:Decrypt"
@@ -133,10 +147,11 @@ module "kms_key" {
   count = var.kms_key_arn == null ? 1 : 0
 
   source  = "schubergphilis/mcaf-kms/aws"
-  version = "~> 0.3.1"
+  version = "~> 2.2.0"
 
-  name        = var.name
-  description = "KMS key used for encrypting all energy labeler resources"
+  name           = var.name
+  default_policy = { enable = false }
+  description    = "KMS key used for encrypting all energy labeler resources"
 }
 
 resource "aws_kms_key_policy" "default" {

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ locals {
 }
 
 resource "aws_security_group" "default" {
-  # checkov:skip=CKV2_AWS_5: False positive finding, the security group is attached.
+  # checkov:skip=CKV2_AWS_5: Security Groups are not attached to EC2 instances or ENIs - False positive finding, the security group is attached.
   name        = var.name
   description = "Security group for ECS cluster ${var.name}"
   vpc_id      = data.aws_subnet.selected.vpc_id
@@ -75,7 +75,7 @@ resource "aws_ecs_cluster" "default" {
 }
 
 data "aws_iam_policy_document" "ecs_task" {
-  # checkov:skip=CKV_AWS_356: Cannot set limit resources for security hub or org
+  # checkov:skip=CKV_AWS_356: Data source IAM policy document allows all resources with restricted actions - Cannot set limit resources for security hub or org
 
   statement {
     sid       = "AllowReadOrg"

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ locals {
       export_path             = "s3://${local.bucket_name_with_prefix}"
       frameworks              = length(var.config.frameworks) > 0 ? join(", ", var.config.frameworks) : null
       organizations_zone_name = var.config.zone_name
-      region                  = data.aws_region.current.name
+      region                  = data.aws_region.current.region
       single_account_id       = var.config.single_account_id
     }
   )
@@ -164,7 +164,7 @@ resource "aws_cloudwatch_event_target" "default" {
 
 module "aws_ecs_container_definition" {
   source  = "terraform-aws-modules/ecs/aws//modules/container-definition"
-  version = "~> 5.12.1"
+  version = "~> 7.5.0"
 
   name                            = var.name
   cloudwatch_log_group_name       = "/aws/ecs/${var.name}"
@@ -172,7 +172,7 @@ module "aws_ecs_container_definition" {
   cloudwatch_log_group_kms_key_id = local.kms_key_arn
   essential                       = true
   image                           = var.image_uri
-  readonly_root_filesystem        = true
+  readonlyRootFilesystem          = true
   tags                            = var.tags
 
   environment = [
@@ -202,7 +202,7 @@ module "s3" {
   count = var.bucket_name == null ? 1 : 0
 
   source  = "schubergphilis/mcaf-s3/aws"
-  version = "~> 1.5.2"
+  version = "~> 3.0.0"
 
   name_prefix = "${lower(var.name)}-"
   kms_key_arn = local.kms_key_arn

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.20"
+      version = ">= 6.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,12 @@ variable "kms_key_decrypt_iam_principals" {
   }
 }
 
+variable "kms_key_administrator_iam_principals" {
+  type        = list(string)
+  default     = []
+  description = "List of IAM principal ARNs allowed to administer the KMS key."
+}
+
 variable "memory" {
   type        = number
   default     = 512


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Makes the module fully compatible with the AWS provider v6 and removes all `Deprecated value used` warnings:

- Replace the deprecated `data.aws_region.*.name` attribute with `.region` (`kms.tf`, `main.tf`).
- Raise the AWS provider floor from `>= 5.20` to `>= 6.0` (`terraform.tf`, example).
- Bump bundled child modules to their v6-compatible releases: `mcaf-s3` `~> 1.5.2` → `~> 3.0.0` and `ecs//modules/container-definition` `~> 5.12.1` → `~> 7.5.0` (incl. the `readonly_root_filesystem` → `readonlyRootFilesystem` rename).
- Sync internal KMS key policy with latest version from the [mcaf-kms](https://github.com/schubergphilis/terraform-aws-mcaf-kms/blob/master/UPGRADING.md#upgrading-to-v200) module, the internal key policy of the module cannot be used due to a cyclic dependency issue.

## :pencil: Additional Information

- **Breaking change** — the provider floor now requires `>= 6.0`. See [`UPGRADING.md`](UPGRADING.md).
- `mcaf-s3` v3.0.0 blocks `SSE-C` uploads by default; no impact here as the bucket is KMS-encrypted (`SSE-KMS`).